### PR TITLE
Update README to fix broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ http-based GET and POST/PUT commands.
 
 ## Online Manual
 
-http://www.testcams.com/canomate
+https://www.testcams.com/canomate
 
 ## Requirements
 


### PR DESCRIPTION
Canomate uses `https` https://www.testcams.com/canomate/